### PR TITLE
feat: patch web3onboard ledger library with rootstock HD path

### DIFF
--- a/patches/@web3-onboard+ledger+2.3.2.patch
+++ b/patches/@web3-onboard+ledger+2.3.2.patch
@@ -1,0 +1,56 @@
+diff --git a/node_modules/@web3-onboard/ledger/dist/index.js b/node_modules/@web3-onboard/ledger/dist/index.js
+index 12bf9df..a1b84d3 100644
+--- a/node_modules/@web3-onboard/ledger/dist/index.js
++++ b/node_modules/@web3-onboard/ledger/dist/index.js
+@@ -2,6 +2,8 @@
+ import { TypedDataUtils } from '@metamask/eth-sig-util';
+ const LEDGER_LIVE_PATH = `m/44'/60'`;
+ const LEDGER_DEFAULT_PATH = `m/44'/60'/0'`;
++const ROOTSTOCK = `m/44'/137'/0'/0'`;
++const ROOTSTOCK_TEST = `m/44'/37310'/0'/0'`;
+ const DEFAULT_BASE_PATHS = [
+     {
+         label: 'Ledger Live',
+@@ -10,11 +12,19 @@ const DEFAULT_BASE_PATHS = [
+     {
+         label: 'Ledger Legacy',
+         value: LEDGER_DEFAULT_PATH
++    },
++    {
++        label: 'Rootstock Path',
++        value: ROOTSTOCK
++    },
++    {
++        label: 'Rootstock Testnet Path',
++        value: ROOTSTOCK_TEST
+     }
+ ];
+ const assets = [
+     {
+-        label: 'ETH'
++        label: 'RBTC'
+     }
+ ];
+ const supportsWebUSB = () => Promise.resolve(!!navigator &&
+@@ -31,7 +41,9 @@ const getAccount = async (derivationPath, asset, index, provider, eth) => {
+     const dPath = derivationPath === LEDGER_LIVE_PATH
+         ? `${derivationPath}/${index}'/0/0`
+         : `${derivationPath}/${index}`;
+-    const { address } = await eth.getAddress(dPath);
++    let { address } = await eth.getAddress(dPath);
++    //Matching rootstock checksum
++    address = address.toLowerCase();
+     return {
+         derivationPath: dPath,
+         address,
+@@ -95,7 +107,9 @@ function ledger({ customNetwork, filter } = {}) {
+                         // Checks to see if this is a custom derivation path
+                         // If it is then just return the single account
+                         if (derivationPath !== LEDGER_LIVE_PATH &&
+-                            derivationPath !== LEDGER_DEFAULT_PATH) {
++                            derivationPath !== LEDGER_DEFAULT_PATH &&
++                            derivationPath !== ROOTSTOCK &&
++                            derivationPath !== ROOTSTOCK_TEST) {
+                             const { address } = await eth.getAddress(derivationPath);
+                             return [
+                                 {


### PR DESCRIPTION
## What it solves

Adds support of custom Rootstock HD paths and converts address to be supported by RSK Testnet and Mainnet APPs

## How this PR fixes it
Patched web3onboard ledger library using patch-package.

## How to test it
- Open RSK Test or RSK Ledger App
- Select related HD path (e.g. Test HD path will work only with RSK TST app and RSK Testnet network)
- Connect and perform some actions
## Screenshots
![RootstockSAFE2](https://github.com/protofire/rootstock-wallet-web/assets/65896721/68514510-69fb-45da-aa26-84849a23ac70)
