### PR TITLE
feat: Trezor support

### DIFF
--- a/.yarn/patches/@web3-onboard-trezor-npm-2.4.3-fdd09231e7.patch
+++ b/.yarn/patches/@web3-onboard-trezor-npm-2.4.3-fdd09231e7.patch
@@ -1,0 +1,103 @@
+diff --git a/dist/index.js b/dist/index.js
+index 0bd514925bad8ed4f0d4a66f281d3b920bb2cc30..c116be245e6ba6569a70a31a473a8b6194c700e5 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,17 +1,51 @@
+ // cannot be dynamically imported
+ import { Buffer } from 'buffer';
+ const TREZOR_DEFAULT_PATH = "m/44'/60'/0'/0";
++const ROOTSTOCK = "m/44'/137'/0'/0";
++const ROOTSTOCK_TEST = "m/44'/37310'/0'/0";
++
+ const assets = [
+     {
+-        label: 'ETH'
++        label: 'RBTC'
+     }
+ ];
+ const DEFAULT_BASE_PATHS = [
+     {
+         label: 'Ethereum Mainnet',
+         value: TREZOR_DEFAULT_PATH
++    },
++    {
++        label: 'Rootstock Path',
++        value: ROOTSTOCK
++    },
++    {
++        label: 'Rootstock Testnet Path',
++        value: ROOTSTOCK_TEST
+     }
+ ];
++
++/**
++ * @description Implements EIP-1191 Address Checksum for Rootstock
++ * @param _address - The address to checksum
++ * @param _chainId - The chain ID (optional)
++ * @returns checksummed address
++ */
++const toRootstockChecksumAddress = async (_address, _chainId = "") => {
++    const ethUtil = await import('ethereumjs-util');
++    // @ts-ignore - Commonjs importing weirdness
++    const { stripHexPrefix, keccak } = ethUtil.default || ethUtil;
++
++    const address = stripHexPrefix(_address).toLowerCase();
++    const chainId = parseInt(_chainId);
++    const prefix = !isNaN(chainId) ? `${chainId.toString()}0x` : "";
++    const hash = keccak(Buffer.from(`${prefix}${address}`)).toString("hex");
++    return ("0x" + address
++        .split("")
++        .map((b, i) => (parseInt(hash[i], 16) >= 8 ? b.toUpperCase() : b))
++        .join("")
++    );
++};
++
+ const getAccount = async ({ publicKey, chainCode, path }, asset, index, provider) => {
+     //@ts-ignore
+     const { default: HDKey } = await import('hdkey');
+@@ -22,7 +56,13 @@ const getAccount = async ({ publicKey, chainCode, path }, asset, index, provider
+     hdk.publicKey = Buffer.from(publicKey, 'hex');
+     hdk.chainCode = Buffer.from(chainCode, 'hex');
+     const dkey = hdk.deriveChild(index);
+-    const address = toChecksumAddress(`0x${publicToAddress(dkey.publicKey, true).toString('hex')}`);
++    let address = toChecksumAddress(`0x${publicToAddress(dkey.publicKey, true).toString('hex')}`);
++
++    // Apply Rootstock checksum for Rootstock paths
++    if (path.includes("m/44'/137") || path.includes("m/44'/37310")) {
++        address = await toRootstockChecksumAddress(address);
++    }
++
+     return {
+         derivationPath: `${path}/${index}`,
+         address,
+@@ -96,8 +136,14 @@ function trezor(options) {
+                     currentChain = chains.find(({ id }) => id === chainId) || currentChain;
+                     ethersProvider = new StaticJsonRpcProvider(currentChain.rpcUrl);
+                     const { publicKey, chainCode, path } = await getPublicKey(derivationPath);
+-                    if (derivationPath !== TREZOR_DEFAULT_PATH) {
+-                        const address = await getAddress(path);
++                    if (derivationPath !== TREZOR_DEFAULT_PATH &&
++                        derivationPath !== ROOTSTOCK &&
++                        derivationPath !== ROOTSTOCK_TEST) {
++                        let address = await getAddress(path);
++                        // Apply Rootstock checksum for custom Rootstock paths
++                        if (derivationPath.includes("m/44'/137") || derivationPath.includes("m/44'/37310")) {
++                            address = await toRootstockChecksumAddress(address);
++                        }
+                         return [
+                             {
+                                 derivationPath,
+@@ -140,7 +186,12 @@ function trezor(options) {
+                         if (!result.success) {
+                             throw new Error(errorMsg);
+                         }
+-                        return result.payload.address;
++                        let address = result.payload.address;
++                        // Apply Rootstock checksum for Rootstock paths
++                        if (path.includes("m/44'/137") || path.includes("m/44'/37310")) {
++                            address = await toRootstockChecksumAddress(address);
++                        }
++                        return address;
+                     }
+                     catch (error) {
+                         console.error(error);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -70,7 +70,7 @@
     "@web3-onboard/core": "2.24.0",
     "@web3-onboard/injected-wallets": "^2.11.3",
     "@web3-onboard/ledger": "patch:@web3-onboard/ledger@npm%3A2.3.2#~/.yarn/patches/@web3-onboard-ledger-npm-2.3.2-d2260df52b.patch",
-    "@web3-onboard/trezor": "2.4.3",
+    "@web3-onboard/trezor": "patch:@web3-onboard/trezor@npm%3A2.4.3#~/.yarn/patches/@web3-onboard-trezor-npm-2.4.3-fdd09231e7.patch",
     "@web3-onboard/walletconnect": "^2.6.1",
     "blo": "^1.1.1",
     "classnames": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10146,7 +10146,7 @@ __metadata:
     "@web3-onboard/core": "npm:2.24.0"
     "@web3-onboard/injected-wallets": "npm:^2.11.3"
     "@web3-onboard/ledger": "patch:@web3-onboard/ledger@npm%3A2.3.2#~/.yarn/patches/@web3-onboard-ledger-npm-2.3.2-d2260df52b.patch"
-    "@web3-onboard/trezor": "npm:2.4.3"
+    "@web3-onboard/trezor": "patch:@web3-onboard/trezor@npm%3A2.4.3#~/.yarn/patches/@web3-onboard-trezor-npm-2.4.3-fdd09231e7.patch"
     "@web3-onboard/walletconnect": "npm:^2.6.1"
     blo: "npm:^1.1.1"
     cheerio: "npm:^1.0.0"
@@ -16161,6 +16161,23 @@ __metadata:
     ethereumjs-util: "npm:^7.1.3"
     hdkey: "npm:^2.0.1"
   checksum: 10/48b5cd480683ad606236a7c50a0a9bf52ac4de8e65cc6b83d7d8c2f4c916d5b189a4aca21d22552166284aed3a8378fef9cc7d0f9718383abecc81bc1446b542
+  languageName: node
+  linkType: hard
+
+"@web3-onboard/trezor@patch:@web3-onboard/trezor@npm%3A2.4.3#~/.yarn/patches/@web3-onboard-trezor-npm-2.4.3-fdd09231e7.patch":
+  version: 2.4.3
+  resolution: "@web3-onboard/trezor@patch:@web3-onboard/trezor@npm%3A2.4.3#~/.yarn/patches/@web3-onboard-trezor-npm-2.4.3-fdd09231e7.patch::version=2.4.3&hash=c3774f"
+  dependencies:
+    "@ethereumjs/tx": "npm:^3.4.0"
+    "@ethersproject/providers": "npm:^5.5.0"
+    "@trezor/connect-web": "npm:^9.0.11"
+    "@web3-onboard/common": "npm:^2.3.3"
+    "@web3-onboard/hw-common": "npm:^2.3.0"
+    buffer: "npm:^6.0.3"
+    eth-crypto: "npm:^2.1.0"
+    ethereumjs-util: "npm:^7.1.3"
+    hdkey: "npm:^2.0.1"
+  checksum: 10/ed384352293cd7ef3dc1e86cff50b5a474d4f10644819aea4179d924e0b56a85e465f15627d41807efad8b4bbce01e964a4af64bd0a4a25111c3b53f5127b58f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds support of custom Rootstock HD paths and converts address to be supported by RSK Testnet and Mainnet APPs

How this PR fixes it
Patched web3onboard trezor library using patch-package.