### PR TITLE
fix(rollout): force legacy tx type for Ledger on Rootstock

### DIFF
--- a/apps/web/src/services/onboard/ledger-module.test.ts
+++ b/apps/web/src/services/onboard/ledger-module.test.ts
@@ -1,0 +1,82 @@
+import { Transaction } from 'ethers'
+import { getLedgerTransactionFeeParams } from './ledger-module'
+
+const ROOTSTOCK_MAINNET_CHAIN_ID = 30n
+const ETHEREUM_CHAIN_ID = 1n
+
+// Build a transaction exactly as the Ledger module's eth_signTransaction handler does, so the
+// assertions exercise the real fee/type logic rather than a copy of it.
+const buildTx = (chainId: bigint, txParams: Parameters<typeof getLedgerTransactionFeeParams>[0]) =>
+  Transaction.from({
+    ...getLedgerTransactionFeeParams(txParams),
+    chainId,
+    to: '0xBD0c770Fb60A196F1C29b437F8c28a0fA753Cac2',
+    value: 0n,
+    data: '0x',
+    nonce: 9,
+    gasLimit: 100_000n,
+  })
+
+describe('getLedgerTransactionFeeParams', () => {
+  it('produces a legacy (type 0) transaction for a gasPrice-only tx (Rootstock)', () => {
+    // Rootstock is legacy-only; the Execute/creation flows pass gasPrice and no EIP-1559 fee caps.
+    const tx = buildTx(ROOTSTOCK_MAINNET_CHAIN_ID, { gasPrice: 65_000_000n })
+
+    expect(tx.type).toBe(0)
+    // Legacy txs serialize as an RLP list (0xc0+); typed txs would start with 0x01 (EIP-2930) or
+    // 0x02 (EIP-1559), which is exactly what Rootstock rejects with "Internal server error".
+    expect(tx.unsignedSerialized.startsWith('0x01')).toBe(false)
+    expect(tx.unsignedSerialized.startsWith('0x02')).toBe(false)
+    expect(tx.gasPrice).toBe(65_000_000n)
+    expect(tx.maxFeePerGas).toBeNull()
+    expect(tx.maxPriorityFeePerGas).toBeNull()
+  })
+
+  it('does not leak EIP-1559 fee caps into a legacy tx even if a stray maxFeePerGas is absent', () => {
+    const params = getLedgerTransactionFeeParams({ gasPrice: 1n })
+
+    expect(params.type).toBe(0)
+    expect(params.maxFeePerGas).toBeNull()
+    expect(params.maxPriorityFeePerGas).toBeNull()
+  })
+
+  it('falls back to legacy (type 0) for degenerate single-cap or fee-less inputs (no throw)', () => {
+    // A lone maxPriorityFeePerGas would otherwise make ethers throw "priorityFee cannot be more than maxFee".
+    expect(getLedgerTransactionFeeParams({ maxPriorityFeePerGas: 1n }).type).toBe(0)
+    expect(getLedgerTransactionFeeParams({ maxFeePerGas: 1n }).type).toBe(0)
+    expect(getLedgerTransactionFeeParams({}).type).toBe(0)
+    // The lone-priority-cap input must still build without throwing
+    expect(() => buildTx(ROOTSTOCK_MAINNET_CHAIN_ID, { maxPriorityFeePerGas: 1n })).not.toThrow()
+  })
+
+  it('produces an EIP-1559 (type 2) transaction when fee caps are provided (EIP-1559 chains)', () => {
+    const tx = buildTx(ETHEREUM_CHAIN_ID, { maxFeePerGas: 65_000_000n, maxPriorityFeePerGas: 1_000_000n })
+
+    expect(tx.type).toBe(2)
+    expect(tx.unsignedSerialized.startsWith('0x02')).toBe(true)
+    expect(tx.maxFeePerGas).toBe(65_000_000n)
+    expect(tx.maxPriorityFeePerGas).toBe(1_000_000n)
+    expect(tx.gasPrice).toBeNull()
+  })
+
+  it('ignores gasPrice when EIP-1559 fee caps are present (no mixed legacy/1559 fields)', () => {
+    const params = getLedgerTransactionFeeParams({
+      gasPrice: 99n,
+      maxFeePerGas: 65_000_000n,
+      maxPriorityFeePerGas: 1_000_000n,
+    })
+
+    expect(params.type).toBe(2)
+    expect(params.gasPrice).toBeNull()
+  })
+
+  it('accepts string-encoded fee values (as received from the EIP-1193 provider)', () => {
+    const legacy = getLedgerTransactionFeeParams({ gasPrice: '0x3e9' })
+    expect(legacy.type).toBe(0)
+    expect(legacy.gasPrice).toBe(1001n)
+
+    const eip1559 = getLedgerTransactionFeeParams({ maxFeePerGas: '0x3e9', maxPriorityFeePerGas: '0x1' })
+    expect(eip1559.type).toBe(2)
+    expect(eip1559.maxFeePerGas).toBe(1001n)
+  })
+})

--- a/apps/web/src/services/onboard/ledger-module.ts
+++ b/apps/web/src/services/onboard/ledger-module.ts
@@ -41,6 +41,33 @@ function isRootstockPath(derivationPath: string): boolean {
   return derivationPath.includes("44'/137'") || derivationPath.includes("44'/37310'")
 }
 
+type LedgerFeeParams = {
+  gasPrice?: string | number | bigint | null
+  maxFeePerGas?: string | number | bigint | null
+  maxPriorityFeePerGas?: string | number | bigint | null
+}
+
+/**
+ * Returns the fee fields and an explicit transaction `type` for a Ledger-signed transaction.
+ *
+ * ethers infers a typed transaction unless `type` is pinned — EIP-2930 (`0x01`) even for a
+ * gasPrice-only tx, EIP-1559 (`0x02`) when fee-cap fields are set. Legacy-only chains such as
+ * Rootstock reject typed transactions: the node returns a generic "Internal server error".
+ * A transaction without EIP-1559 fee caps must therefore be serialized as legacy (type 0).
+ */
+export const getLedgerTransactionFeeParams = (txParams: LedgerFeeParams) => {
+  // A type-2 (EIP-1559) tx requires BOTH fee caps; any other combination is a legacy (type 0) tx.
+  // Requiring both also avoids ethers throwing "priorityFee cannot be more than maxFee" when only
+  // one cap is supplied.
+  const isLegacy = !(txParams.maxFeePerGas && txParams.maxPriorityFeePerGas)
+  return {
+    type: isLegacy ? 0 : 2,
+    gasPrice: isLegacy && txParams.gasPrice ? BigInt(txParams.gasPrice) : null,
+    maxFeePerGas: !isLegacy && txParams.maxFeePerGas ? BigInt(txParams.maxFeePerGas) : null,
+    maxPriorityFeePerGas: !isLegacy && txParams.maxPriorityFeePerGas ? BigInt(txParams.maxPriorityFeePerGas) : null,
+  }
+}
+
 const DEFAULT_ASSETS: Array<Asset> = [
   {
     label: 'ETH',
@@ -164,12 +191,10 @@ export function ledgerModule(): WalletInit {
                 })) as string)
 
               const transaction = Transaction.from({
+                ...getLedgerTransactionFeeParams(txParams),
                 chainId: BigInt(currentChain.id),
                 data: txParams.data,
                 gasLimit: gasLimit ? BigInt(gasLimit) : null,
-                gasPrice: txParams.gasPrice ? BigInt(txParams.gasPrice) : null,
-                maxFeePerGas: txParams.maxFeePerGas ? BigInt(txParams.maxFeePerGas) : null,
-                maxPriorityFeePerGas: txParams.maxPriorityFeePerGas ? BigInt(txParams.maxPriorityFeePerGas) : null,
                 nonce: parseInt(nonce, 16),
                 to: txParams.to,
                 value: txParams.value ? BigInt(txParams.value) : null,


### PR DESCRIPTION
## Problem

Executing a transaction **or creating a Safe** with a **Ledger** on Rootstock Mainnet fails with `Internal server error` (Code 804), while the same actions succeed with **MetaMask**. Reported on a 3/3 Safe ([`0xBD0c…Cac2`](https://safe.rootstock.io/transactions/queue?safe=rsk:0xBD0c770Fb60A196F1C29b437F8c28a0fA753Cac2)); also reproduced on single-owner Safe creation.

## Root cause

The error is **not** a Safe signature failure. On-chain forensics confirmed all signatures recover to valid owners and `checkSignatures` passes — `Internal server error` is not a `GSxxx` revert string, it's the RSK node rejecting the raw transaction.

The custom Ledger module (`ledger-module.ts`) builds the broadcast transaction with `ethers` `Transaction.from()` **without pinning `type`**. ethers v6 then infers a **typed** transaction:

- `gasPrice`-only → **`0x01`** (EIP-2930)
- any EIP-1559 fee cap → **`0x02`** (EIP-1559)
- never a legacy (type-0) tx

Rootstock is **legacy-only** (no `baseFeePerGas`, `EIP1559` disabled in its chain config), so its node can't decode the `0x01`/`0x02`-prefixed raw tx and returns a generic `Internal server error`. This is the shared broadcast path for **both** multisig execution and Safe creation, which is why both fail — and why MetaMask works (it builds its own legacy tx for RSK).

Verified empirically against the repo's ethers: `gasPrice`-only → `0x01`; pinning `type: 0` → `0xe4` (legacy EIP-155 RLP).

## Fix

Pin the transaction type explicitly via a new exported, unit-testable helper `getLedgerTransactionFeeParams`:

- **legacy (type 0)** with `gasPrice` when no EIP-1559 fee caps are present (Rootstock and other legacy chains)
- **type 2** with both fee caps otherwise (EIP-1559 chains)

Requiring **both** caps for type-2 also avoids ethers throwing `priorityFee cannot be more than maxFee` on a malformed single-cap input.

## Tests

`ledger-module.test.ts` (Ledger-free) asserts the real helper + real `ethers.Transaction.from`:
- gasPrice-only (Rootstock) → `type === 0`, serialization is **not** `0x01`/`0x02`
- EIP-1559 inputs → `type === 2`, `0x02` prefix
- degenerate single-cap / fee-less inputs → legacy, no throw
- string-encoded (`0x…`) fee values

`type-check`, `lint`, `prettier`, and the new tests pass.

## Note

This supersedes the reverted `collect real signature for hardware wallet execution` commit, which targeted the wrong layer (the v=1 `msg.sender` approval) — investigation showed the signatures were always valid and the failure was in the raw-transaction encoding.

## Remaining (needs a device)

End-to-end confirmation that the RSK Ledger app signs the corrected legacy payload with a correct EIP-155 `v` requires a real Ledger.